### PR TITLE
Add use-logical rule

### DIFF
--- a/stylelint/index.js
+++ b/stylelint/index.js
@@ -93,7 +93,7 @@ module.exports = {
 
 		'declaration-empty-line-before': null,
 		'comment-empty-line-before': null,
-
+		'csstools/use-logical': 'always',
 		'plugin/no-unsupported-browser-features': [
 			true, {
 				browsers: [ 
@@ -111,5 +111,6 @@ module.exports = {
 		'stylelint-no-unsupported-browser-features',
 		'stylelint-high-performance-animation',
 		'stylelint-declaration-block-no-ignored-properties',
+		'stylelint-use-logical',
 	],
 }

--- a/stylelint/package.json
+++ b/stylelint/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "stylelint-config-goodbyte-styleguide",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"description": "A Stylelint configuration following (and defining) the Goodbyte Styleguide",
 	"author": "Goodbyte <build@goodbyte.ca>",
 	"license": "MIT",
@@ -30,13 +30,7 @@
 		"stylelint-config-standard": "^22.0.0",
 		"stylelint-declaration-block-no-ignored-properties": "^2.4.0",
 		"stylelint-high-performance-animation": "^1.5.2",
-		"stylelint-no-unsupported-browser-features": "^5.0.1"
-	},
-	"devDependencies": {
-		"stylelint": "^13.13.1",
-		"stylelint-config-standard": "^22.0.0",
-		"stylelint-declaration-block-no-ignored-properties": "^2.4.0",
-		"stylelint-high-performance-animation": "^1.5.2",
-		"stylelint-no-unsupported-browser-features": "^5.0.1"
+		"stylelint-no-unsupported-browser-features": "^5.0.1",
+		"stylelint-use-logical": "^1.1.0"
 	}
 }


### PR DESCRIPTION
Adds the [stylelint-use-logical](https://github.com/csstools/stylelint-use-logical/blob/master/README.md) plugin to replace `text-align: left` with `start`, as well as similar cases.

closes #9 